### PR TITLE
0.2.2

### DIFF
--- a/datar/__init__.py
+++ b/datar/__init__.py
@@ -4,4 +4,4 @@ from .core import operator as _
 from .core import frame_format_patch as _
 from .core.defaults import f
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'

--- a/datar/all.py
+++ b/datar/all.py
@@ -2,37 +2,35 @@
 # pylint: disable=wildcard-import, unused-wildcard-import
 # pylint: disable=unused-import, reimported, invalid-name
 from . import f
-from .base import _no_warn as _
+from .base import (
+    _no_warn as _  # don't override from datar.all import _no_warn
+)
+from .base import _builtin_names as _base_builtin_names
 from .base import *
 from .base import _warn as _
-from .utils import *
-from .stats import *
+from .datar import *
 from .dplyr import _no_warn as _
+from .dplyr import _builtin_names as _dplyr_builtin_names
 from .dplyr import *
 from .dplyr import _warn as _
-from .tidyr import *
+from .stats import *
 from .tibble import *
-from .datar import *
+from .tidyr import *
+from .utils import *
 
-from . import base as _base, dplyr as _dplyr
-from .core.warn_builtin_names import warn_builtin_names as _warn_builtin_names
-
-_builtin_names = dict(
-    filter=_dplyr.dfilter,
-    slice=_dplyr.dslice,
-    min=_base.arithmetic,
-    max=_base.arithmetic,
-    sum=_base.arithmetic,
-    abs=_base.arithmetic,
-    round=_base.arithmetic,
-    all=_base.testing,
-    any=_base.testing,
-    re=_base.complex
-)
-__all__ = [name for name in locals() if not name.startswith('_')]
+_builtin_names = _base_builtin_names.copy()
+_builtin_names.update(_dplyr_builtin_names)
+# builtin names included
+__all__ = [var_ for var_ in locals() if not var_.startswith('_')]
 
 for name in _builtin_names:
-    # let __getattr__ handles the builtins
+    # let __getattr__ handles the builtins, otherwise
+    # from datar.all import filter
+    # will not warn
     del locals()[name]
+
+from .core.warn_builtin_names import ( # pylint: disable=wrong-import-position
+    warn_builtin_names as _warn_builtin_names
+)
 
 __getattr__ = _warn_builtin_names(**_builtin_names)

--- a/datar/base/__init__.py
+++ b/datar/base/__init__.py
@@ -1,87 +1,160 @@
 """Public APIs from this submodule"""
 # pylint: disable=unused-import
-from .constants import (
-    pi, Inf, letters, LETTERS, month_abb, month_name
+from ..core.options import get_option, options, options_context
+from .arithmetic import (
+    ceiling,
+    cov,
+    floor,
+    mean,
+    median,
+    pmax,
+    pmin,
+    sqrt,
+    var,
+    min as min_,
+    max as max_,
+    round as round_,
+    sum as sum_,
+    abs as abs_
 )
-from ..core.options import options, get_option, options_context
-from .verbs import (
-    colnames, rownames, dim, nrow, ncol, diag, t, names,
-    intersect, union, setdiff, setequal, duplicated
-)
-from .funs import (
-    cut, identity, expandgrid, data_context
-)
-from .arithmetic import mean, median, pmin, pmax, var, ceiling, floor, sqrt, cov
 from .bessel import bessel_i, bessel_j, bessel_k, bessel_y
-from .casting import as_integer, as_float, as_double, as_int, as_numeric
-from .complex import im, mod, arg, conj, is_complex, as_complex
-from .cum import cumsum, cumprod, cummin, cummax
+from .casting import as_double, as_float, as_int, as_integer, as_numeric
+from .complex import arg, as_complex, conj, im, is_complex, mod, re as re_
+from .constants import LETTERS, Inf, letters, month_abb, month_name, pi
+from .cum import cummax, cummin, cumprod, cumsum
 from .date import as_date
 from .factor import (
-    factor, droplevels, levels,
-    is_factor, is_categorical, as_factor, as_categorical
+    as_categorical,
+    as_factor,
+    droplevels,
+    factor,
+    is_categorical,
+    is_factor,
+    levels
 )
+from .funs import cut, data_context, expandgrid, identity
 from .logical import (
-    TRUE, FALSE,
-    is_true, is_false,
-    is_bool, is_logical,
-    as_bool, as_logical
+    FALSE,
+    TRUE,
+    as_bool,
+    as_logical,
+    is_bool,
+    is_false,
+    is_logical,
+    is_true
 )
-from .na import NA, NaN, is_na, any_na
-from .null import NULL, is_null, as_null
+from .na import NA, NaN, any_na, is_na
+from .null import NULL, as_null, is_null
 from .random import set_seed
 from .seq import (
-    c, seq, seq_len, seq_along, rev, rep, lengths, unique, sample, length
+    c,
+    length,
+    lengths,
+    rep,
+    rev,
+    sample,
+    seq,
+    seq_along,
+    seq_len,
+    unique
 )
-
 from .special import (
-    beta, lbeta, gamma, lgamma, digamma, trigamma, psigamma,
-    choose, lchoose, factorial, lfactorial
+    beta,
+    choose,
+    digamma,
+    factorial,
+    gamma,
+    lbeta,
+    lchoose,
+    lfactorial,
+    lgamma,
+    psigamma,
+    trigamma
 )
 from .string import (
-    is_str, is_string, is_character, as_str, as_string, as_character,
-    grep, grepl, sub, gsub, nchar, nzchar, paste, paste0, sprintf,
-    substr, substring, strsplit
+    as_character,
+    as_str,
+    as_string,
+    grep,
+    grepl,
+    gsub,
+    is_character,
+    is_str,
+    is_string,
+    nchar,
+    nzchar,
+    paste,
+    paste0,
+    sprintf,
+    strsplit,
+    sub,
+    substr,
+    substring
 )
 from .table import table
 from .testing import (
-    is_double, is_float, is_int, is_integer, is_numeric,
-    is_atomic, is_element, is_in
+    is_atomic,
+    is_double,
+    is_element,
+    is_float,
+    is_in,
+    is_int,
+    is_integer,
+    is_numeric,
+    any as any_,
+    all as all_
 )
 from .trig_hb import (
-    cos, sin, tan, acos, asin, atan, atan2, cospi, sinpi, tanpi,
-    cosh, sinh, tanh, acosh, asinh, atanh
+    acos,
+    acosh,
+    asin,
+    asinh,
+    atan,
+    atan2,
+    atanh,
+    cos,
+    cosh,
+    cospi,
+    sin,
+    sinh,
+    sinpi,
+    tan,
+    tanh,
+    tanpi
 )
-from .which import which, which_min, which_max
+from .verbs import (
+    colnames,
+    diag,
+    dim,
+    duplicated,
+    intersect,
+    names,
+    ncol,
+    nrow,
+    rownames,
+    setdiff,
+    setequal,
+    t,
+    union
+)
+from .which import which, which_max, which_min
 
 __all__ = [name for name in locals() if not name.startswith('_')]
-__all__.extend([
-    "min",
-    "max",
-    "sum",
-    "abs",
-    "round",
-    "all",
-    "any",
-    "re",
-])
+
+_builtin_names = { # pylint: disable=invalid-name
+    "min": min_,
+    "max": max_,
+    "sum": sum_,
+    "abs": abs_,
+    "round": round_,
+    "all": all_,
+    "any": any_,
+    "re": re_
+}
+__all__.extend(_builtin_names)
 
 # warn when builtin names are imported directly
 # pylint: disable=wrong-import-position
 from ..core.warn_builtin_names import warn_builtin_names
-from . import (
-    arithmetic as _arithmetic,
-    testing as _testing,
-    complex as _complex
-)
 
-__getattr__ = warn_builtin_names(
-    min=_arithmetic,
-    max=_arithmetic,
-    sum=_arithmetic,
-    abs=_arithmetic,
-    round=_arithmetic,
-    all=_testing,
-    any=_testing,
-    re=_complex
-)
+__getattr__ = warn_builtin_names(**_builtin_names)

--- a/datar/base/string.py
+++ b/datar/base/string.py
@@ -224,6 +224,9 @@ def _match(
         fixed: bool
 ) -> bool:
     """Do the regex match"""
+    if is_null(text):
+        return False
+
     flags = re.IGNORECASE if ignore_case else 0
     if fixed:
         pattern = re.escape(pattern)
@@ -253,6 +256,9 @@ def _sub(
 
     flags = re.IGNORECASE if ignore_case else 0
     pattern = re.compile(pattern, flags)
+
+    if is_scalar(x):
+        return pattern.sub(repl=replacement, count=count, string=x)
 
     return Array([
         pattern.sub(repl=replacement, count=count, string=elem)
@@ -358,6 +364,7 @@ def _nchar_scalar(
 
 # paste and paste0 --------------------
 
+@register_func(None, context=Context.EVAL)
 def paste(
         *args: StringOrIter,
         sep: str = " ",
@@ -380,6 +387,7 @@ def paste(
     out = [sep.join(arg) for arg in args]
     if collapse is not None:
         return collapse.join(out)
+
     return Array(out, dtype=str)
 
 @register_func(None, context=Context.EVAL)

--- a/datar/core/warn_builtin_names.py
+++ b/datar/core/warn_builtin_names.py
@@ -1,13 +1,12 @@
 """Let datar warn when builtin names are tried to be imported"""
 import sys
 from typing import Callable, Any
-from types import ModuleType
 from executing import Source
 
 WARNED = set()
 
 def warn_builtin_names(
-        **names: ModuleType
+        **names: Callable
 ) -> Callable[[str], Any]:
     """Generate __getattr__ function to warn the builtin names"""
     from .utils import logger, get_option
@@ -45,13 +44,8 @@ def warn_builtin_names(
             warn = False
             return None
 
-        rname = name[:-1] if name.endswith('_') else name
-
-        if name == '__path__' or rname not in names:
+        if name == '__path__' or name not in names:
             raise AttributeError
-
-        if rname != name:
-            return getattr(names[rname], rname)
 
         if warn and name not in WARNED and get_option('warn.builtin.names'):
             node = Source.executing(sys._getframe(1)).node
@@ -61,6 +55,6 @@ def warn_builtin_names(
                     'Builtin name "%s" has been overriden by datar.',
                     name
                 )
-        return getattr(names[name], name)
+        return names[name]
 
     return _getattr

--- a/datar/dplyr/__init__.py
+++ b/datar/dplyr/__init__.py
@@ -1,69 +1,115 @@
 """Public APIs for dplyr"""
 
 # pylint: disable=unused-import
-from .sets import union_all, union, setdiff, intersect, setequal
-from .funs import (
-    cummean, cumall, cumany,
-    coalesce, na_if, near, nth, first, last, between
-)
-
-from .group_by import group_by_drop_default, group_by, rowwise, ungroup
-from .group_data import (
-    group_data, group_keys, group_rows, group_indices,
-    group_vars, group_size, n_groups, group_cols
-)
-from .join import (
-    inner_join, left_join, right_join, full_join,
-    semi_join, anti_join, nest_join
-)
-from .summarise import summarise, summarize
-from .count_tally import count, tally, add_count, add_tally
-from .desc import desc
-from .arrange import arrange
-from .context import (
-    n, cur_data_all, cur_group_id, cur_group_rows,
-    cur_group, cur_data, cur_column
-)
-from .mutate import mutate, transmute
-from .select import select
 from .across import across, c_across, if_all, if_any
-from .tidyselect import (
-    where, everything, last_col,
-    starts_with, ends_with, contains, matches,
-    all_of, any_of, num_range
-)
-from .if_else import if_else, case_when
-from .relocate import relocate
-from .distinct import distinct, n_distinct
-from .dslice import  (
-    slice_head, slice_tail, slice_min,
-    slice_max, slice_sample
-)
-from .rank import (
-    ntile, row_number, min_rank, dense_rank, percent_rank, cume_dist
-)
+from .arrange import arrange
 from .bind import bind_cols, bind_rows
-from .rename import rename, rename_with
-from .group_iter import (
-    group_map, group_modify, group_walk, group_trim, group_split, with_groups
+from .context import (
+    cur_column,
+    cur_data,
+    cur_data_all,
+    cur_group,
+    cur_group_id,
+    cur_group_rows,
+    n
 )
-from .pull import pull
-from .lead_lag import lead, lag
-from .recode import recode, recode_factor, recode_categorical
+from .count_tally import add_count, add_tally, count, tally
+from .desc import desc
+from .dfilter import filter as filter_
+from .distinct import distinct, n_distinct
+from .dslice import slice as slice_
+from .dslice import slice_head, slice_max, slice_min, slice_sample, slice_tail
+from .funs import (
+    between,
+    coalesce,
+    cumall,
+    cumany,
+    cummean,
+    first,
+    last,
+    na_if,
+    near,
+    nth
+)
+from .group_by import group_by, group_by_drop_default, rowwise, ungroup
+from .group_data import (
+    group_cols,
+    group_data,
+    group_indices,
+    group_keys,
+    group_rows,
+    group_size,
+    group_vars,
+    n_groups
+)
+from .group_iter import (
+    group_map,
+    group_modify,
+    group_split,
+    group_trim,
+    group_walk,
+    with_groups
+)
+from .if_else import case_when, if_else
+from .join import (
+    anti_join,
+    full_join,
+    inner_join,
+    left_join,
+    nest_join,
+    right_join,
+    semi_join
+)
+from .lead_lag import lag, lead
+from .mutate import mutate, transmute
 from .order_by import order_by, with_order
-from .rows import rows_insert, rows_update, rows_patch, rows_upsert, rows_delete
+from .pull import pull
+from .rank import (
+    cume_dist,
+    dense_rank,
+    min_rank,
+    ntile,
+    percent_rank,
+    row_number
+)
+from .recode import recode, recode_categorical, recode_factor
+from .relocate import relocate
+from .rename import rename, rename_with
+from .rows import (
+    rows_delete,
+    rows_insert,
+    rows_patch,
+    rows_update,
+    rows_upsert
+)
+from .select import select
+from .sets import intersect, setdiff, setequal, union, union_all
+from .summarise import summarise, summarize
+from .tidyselect import (
+    all_of,
+    any_of,
+    contains,
+    ends_with,
+    everything,
+    last_col,
+    matches,
+    num_range,
+    starts_with,
+    where
+)
 
 # make sure builtin names are included when
 # from datar.dplyr import *
-__all__ = [name for name in locals() if not name.startswith('_')]
-__all__.extend(['filter', 'slice'])
+_builtin_names = { # pylint: disable=invalid-name
+    "filter": filter_,
+    "slice": slice_
+}
+
+__all__ = [var_ for var_ in locals() if not var_.startswith('_')]
+__all__.extend(_builtin_names)
 
 # warn when builtin names are imported directly
 # pylint: disable=wrong-import-position
 from ..core.warn_builtin_names import warn_builtin_names
-from . import dfilter as _dfilter, dslice as _dslice
 
-__getattr__ = warn_builtin_names(
-    filter=_dfilter,
-    slice=_dslice
-)
+__getattr__ = warn_builtin_names(**_builtin_names)

--- a/datar/dplyr/mutate.py
+++ b/datar/dplyr/mutate.py
@@ -138,7 +138,7 @@ def _(
         index = df.attrs['_group_index']
         rows = df.attrs['_group_data'].loc[index, '_rows']
         ret = mutate(
-            df,
+            df.reset_index(drop=True),
             *args,
             _keep=_keep,
             _before=_before,

--- a/datar/tidyr/pivot_wide.py
+++ b/datar/tidyr/pivot_wide.py
@@ -150,18 +150,19 @@ def pivot_wider(
         aggfunc=values_fn
     )
 
-    if len(id_cols) > 0:
-        ret.reset_index(inplace=True)
-
-    if ROWID_COLUMN in ret:
-        ret.drop(columns=[ROWID_COLUMN], level=0, inplace=True)
-
     ret.columns = _flatten_column_names(
         ret.columns,
         names_prefix,
         names_sep,
         names_glue
     )
+
+    if len(id_cols) > 0:
+        ret.reset_index(inplace=True)
+
+    if ROWID_COLUMN in ret:
+        ret.drop(columns=[ROWID_COLUMN], inplace=True)
+
     ret.reset_index(drop=True, inplace=True)
     # Get the original NAs back
     for col in ret.columns.difference(id_cols):
@@ -193,22 +194,22 @@ def _flatten_column_names(
     """
     lvlnames = ['_value' if level is None else level for level in names.names]
     out = []
-
     for cols in names:
         if is_scalar(cols):
-            out.append(f'{names_prefix}{cols}')
-            continue
+            cols = [cols]
+            # out.append(f'{names_prefix}{cols}')
+            # continue
         # if len(cols) == 1:
         #     out.append(f'{names_prefix}{cols[0]}')
         #     continue
 
         cols = dict(zip(lvlnames, (str(col) for col in cols)))
         # in case of ('id', '', '')
-        if all(name == '' for key, name in cols.items() if key != '_value'):
-            out.append(f'{names_prefix}{cols["_value"]}')
+        # if all(name == '' for key, name in cols.items() if key != '_value'):
+        #     out.append(f'{names_prefix}{cols["_value"]}')
         # in case of values_from is a dataframe column
         # ('d$a', 'X', '1')
-        elif '$' in cols.get('_value', ''):
+        if '$' in cols.get('_value', ''):
             prefix = names_prefix + names_sep.join(
                 col for name, col in cols.items() if name != '_value'
             )

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.2.2
+- Use a better strategy warning for builtin name overriding.
+- Fix index of subdf not dropped for mutate on grouped data
+- Fix `names_glue` not working with single `values_from` for `tidyr.pivot_wider`
+- Fix `base.paste` not registered
+- Fix `base.grep`/`grepl` on NA values
+- Make `base.sub`/`gsub` return scalar when inputs are scalar strings
+
 ## 0.2.1
 - Use observed values for non-observsed value match for group_data instead of NAs, which might change the dtype.
 - Fix tibble recycling values too early

--- a/docs/import.md
+++ b/docs/import.md
@@ -12,7 +12,7 @@ from datar.all import mutate
 
 !!! Attention
 
-    When you use `from datar.all import *`, you need to pay attention to the python builtin names that are covered by `datar`. For example, `slice` will be `datar.dplyr.slice` instead of `builtins.slice`. To refer to the builtin one, you need to:
+    When you use `from datar.all import *`, you need to pay attention to the python builtin names that are covered by `datar` (will warn by default). For example, `slice` will be `datar.dplyr.slice` instead of `builtins.slice`. To refer to the builtin one, you need to:
     ```python
     import builtins
 
@@ -116,3 +116,25 @@ There are a couple of ways to disable:
 >>> logger.setLevel(40)
 >>> from datar.dplyr import * # ok
 ```
+
+4. Use aliases instead
+
+```python
+>>> from datar.all import filter
+[2021-06-24 10:06:19][datar][WARNING] Builtin name "filter" has been overriden by datar.
+```
+
+But this is Okay:
+```python
+>>> from datar.all import filter_
+>>> filter_
+<function filter at 0x7fc93396df80>
+```
+
+Or you could even aliase it to `filter` by yourself:
+```python
+>>> from datar.all import filter_ as filter # no warnings
+>>> filter
+<function filter at 0x7fc93396df80>
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "datar"
-version = "0.2.1"
+version = "0.2.2"
 description = "Port of dplyr and other related R packages in python, using pipda."
 authors = ["pwwang <pwwang@pwwang.com>"]
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if os.path.exists(readme_path):
 setup(
     long_description=readme,
     name='datar',
-    version='0.2.1',
+    version='0.2.2',
     description='Port of dplyr and other related R packages in python, using pipda.',
     python_requires='==3.*,>=3.7.1',
     project_urls={"homepage": "https://github.com/pwwang/datar",

--- a/tests/test_dplyr_arrange.py
+++ b/tests/test_dplyr_arrange.py
@@ -1,6 +1,7 @@
 # https://github.com/tidyverse/dplyr/blob/master/tests/testthat/test-arrange.r
 
 import pytest
+from pandas.testing import assert_frame_equal
 from datar.all import *
 from datar.core.grouped import DataFrameGroupBy
 from datar.core.exceptions import ColumnNotExistingError, DataUnrecyclable, NameNonUniqueError
@@ -59,7 +60,8 @@ def test_ignores_group():
     assert out.equals(df.iloc[[3,2,1,0], :].reset_index(drop=True))
 
     out = gf >> arrange(f.x, _by_group=True)
-    assert out.equals(df.iloc[[3,1,2,0], :].reset_index(drop=True))
+    exp = df.iloc[[3,1,2,0], :].reset_index(drop=True)
+    assert_frame_equal(out, exp)
 
 def test_update_grouping():
     df = tibble(g = [2, 2, 1, 1], x = [1, 3, 2, 4])

--- a/tests/test_dplyr_context.py
+++ b/tests/test_dplyr_context.py
@@ -1,6 +1,7 @@
 # https://github.com/tidyverse/dplyr/blob/master/tests/testthat/test-context.R
 import pytest
 
+from pandas.testing import assert_frame_equal
 from datar.all import *
 
 def test_cur_group():
@@ -27,7 +28,7 @@ def test_cur_group_id():
 
     out = gf >> mutate(id=cur_group_id())
     expect = tibble(x=["b", "a","b"], id=[1,0,1])
-    assert out.equals(expect)
+    assert_frame_equal(out, expect)
 
 def test_cur_data_all():
     df = tibble(x = c("b", "a", "b"), y = [1,2,3])

--- a/tests/test_dplyr_count.py
+++ b/tests/test_dplyr_count.py
@@ -1,6 +1,6 @@
 # https://github.com/tidyverse/dplyr/blob/master/tests/testthat/test-count-tally.r
-from pandas.core.groupby import groupby
 from datar.core.grouped import DataFrameGroupBy
+from pandas.testing import assert_frame_equal
 from pandas.core.frame import DataFrame
 import pytest
 
@@ -128,12 +128,12 @@ def test_can_add_tallies_of_a_variable():
     df = tibble(a=c(2,1,1))
     out = df >> group_by(f.a) >> add_tally()
     exp = group_by(tibble(a=c(2,1,1), n=c(1,2,2)), f.a)
-    assert out.equals(exp)
+    assert_frame_equal(out, exp)
     assert group_vars(out) == group_vars(exp)
     # sort
     out = df >> group_by(f.a) >> add_tally(sort=True)
     exp = group_by(tibble(a=c(1,1,2), n=c(2,2,1)), f.a)
-    assert out.equals(exp)
+    assert_frame_equal(out, exp)
     assert group_vars(out) == group_vars(exp)
 
 def test_add_tally_can_be_given_a_weighting_variable():

--- a/tests/test_tidyr_pivot_wide.py
+++ b/tests/test_tidyr_pivot_wide.py
@@ -78,6 +78,27 @@ def test_names_glue_affects_output_names():
     )
     assert out.columns.tolist() == ['X1_a', 'Y2_a', 'X1_b', 'Y2_b']
 
+    # single values_from
+    # https://stackoverflow.com/questions/42516817/reproduce-rs-summarise-reshape-result-in-python
+    df = tribble(
+        f.project, f.resourcetype, f.count,
+        1000001,   "O",            7,
+        1000002,   "O",            6,
+        1000003,   "O",            18,
+        1000004,   "C",            1,
+        1000004,   "I",            1,
+        1000004,   "O",            19,
+        1000005,   "I",            2,
+        1000005,   "O",            11,
+        1000006,   "O",            4,
+    )
+    out = df >> pivot_wider(
+        names_from=f.resourcetype,
+        names_glue="count_{resourcetype}",
+        values_from=f.count,
+    )
+    assert_iterable_equal(out.columns, ['project', 'count_C', 'count_I', 'count_O'])
+
 def test_can_sort_column_names():
     df = tibble(
         int=[1,3,2],


### PR DESCRIPTION
- Use a better strategy warning for builtin name overriding.
- Fix index of subdf not dropped for mutate on grouped data
- Fix `names_glue` not working with single `values_from` for `tidyr.pivot_wider`
- Fix `base.paste` not registered
- Fix `base.grep`/`grepl` on NA values
- Make `base.sub`/`gsub` return scalar when inputs are scalar strings