### PR TITLE
0.4.1

### DIFF
--- a/datar/__init__.py
+++ b/datar/__init__.py
@@ -7,19 +7,45 @@ from .core import _frame_format_patch
 from .core.defaults import f
 
 __all__ = ('f', 'datar_versions')
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
-def datar_versions() -> Mapping[str, str]: # pragma: no cover
-    """Get related versions which help for bug reporting."""
+def datar_versions(
+    prnt: bool = True
+) -> Mapping[str, str]: # pragma: no cover
+    """Print or return related versions which help for bug reporting.
 
+    Args:
+        prnt: Print the versions instead of returning them?
+
+    Returns:
+        A `Diot` object of the versions.
+    """
+    import sys
+
+    import numpy
     import pandas
     import pipda
+    import executing
     import varname
     from diot import Diot
 
-    return Diot(
+    out = Diot(
+        python=sys.version,
         datar=__version__,
+        numpy=numpy.__version__,
         pandas=pandas.__version__,
         pipda=pipda.__version__,
+        executing=executing.__version__,
         varname=varname.__version__,
     )
+    if not prnt:
+        return out
+
+    keylen = max(map(len, out))
+    for key, ver in out.items():
+        verlines = ver.splitlines()
+        print(f"{key.ljust(keylen)}: {verlines.pop(0)}")
+        for verline in verlines:
+            print(f"{' ' * keylen}  {verline}")
+
+    return None

--- a/datar/__init__.py
+++ b/datar/__init__.py
@@ -18,6 +18,7 @@ def datar_versions() -> Mapping[str, str]: # pragma: no cover
     from diot import Diot
 
     return Diot(
+        datar=__version__,
         pandas=pandas.__version__,
         pipda=pipda.__version__,
         varname=varname.__version__,

--- a/datar/dplyr/join.py
+++ b/datar/dplyr/join.py
@@ -227,11 +227,11 @@ def semi_join(
     ret = pandas.merge(
         x,
         y,
-        on=by,
         how="left",
         copy=copy,
         suffixes=["", "_y"],
         indicator="__merge__",
+        **_merge_on(by)
     )
     ret = ret.loc[ret["__merge__"] == "both", x.columns.tolist()]
 
@@ -257,11 +257,11 @@ def anti_join(
     ret = pandas.merge(
         x,
         y,
-        on=by,
         how="left",
         copy=copy,
         suffixes=["", "_y"],
         indicator=True,
+        **_merge_on(by)
     )
     ret = ret.loc[ret._merge != "both", x.columns.tolist()]
 
@@ -327,3 +327,19 @@ def nest_join(
             _group_data=group_data(x),
         )
     return out
+
+
+def _merge_on(
+    by: Union[StringOrIter, Mapping[str, str]]
+) -> Mapping[str, StringOrIter]:
+    """Calculate argument on for pandas.merge()"""
+    if by is None:
+        return {}
+    if isinstance(by, dict):
+        return {
+            'left_on': list(by),
+            'right_on': list(by.values())
+        }
+    return {
+        'on': by
+    }

--- a/datar/dplyr/join.py
+++ b/datar/dplyr/join.py
@@ -340,6 +340,4 @@ def _merge_on(
             'left_on': list(by),
             'right_on': list(by.values())
         }
-    return {
-        'on': by
-    }
+    return {'on': by}

--- a/datar/tidyr/pivot_long.py
+++ b/datar/tidyr/pivot_long.py
@@ -184,12 +184,12 @@ def pivot_longer(
         ret[values_to] = ret[values_to].astype("category")
 
     if names_pattern:
-        ret >>= extract(var_name, into=names_to, regex=names_pattern)
+        ret = extract(ret, var_name, into=names_to, regex=names_pattern)
 
     if names_sep:
-        ret >>= separate(var_name, into=names_to, sep=names_sep)
+        ret = separate(ret, var_name, into=names_to, sep=names_sep)
     # extract/separate puts `into` last
-    ret >>= relocate(values_to, _after=-1, base0_=True)
+    ret = relocate(ret, values_to, _after=-1, base0_=True)
 
     if ".value" in names_to:
         names_to = setdiff(names_to, [".value"])

--- a/datar/tidyr/separate.py
+++ b/datar/tidyr/separate.py
@@ -127,7 +127,7 @@ def separate(
     apply_dtypes(separated, convert)
 
     out = data.drop(columns=[col]) if remove else data
-    out >>= mutate(separated)
+    out = mutate(out, separated)
 
     return reconstruct_tibble(data, out)
 
@@ -173,7 +173,7 @@ def separate_rows(
             missing_warns=[],
         )
 
-    out >>= unchop(selected, keep_empty=True, ptype=convert, base0_=base0_)
+    out = unchop(out, selected, keep_empty=True, ptype=convert, base0_=base0_)
     return reconstruct_tibble(out, ungroup(out), selected, keep_rowwise=True)
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.1
+
+- Don't use piping syntax internally (`>>=`)
+- Add `python`, `numpy` and `datar` version to `datar.datar_versions()`
+- Fix #40: anti_join/semi_join not working when by is column mapping
+
 ## 0.4.0
 
 - Adopt `pipda` v0.4.2

--- a/docs/notebooks/filter-joins.ipynb
+++ b/docs/notebooks/filter-joins.ipynb
@@ -3,99 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "specified-enemy",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-07-16T22:27:41.370298Z",
-     "iopub.status.busy": "2021-07-16T22:27:41.368998Z",
-     "iopub.status.idle": "2021-07-16T22:27:42.302245Z",
-     "shell.execute_reply": "2021-07-16T22:27:42.302701Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[2021-07-16 15:27:42][datar][WARNING] Builtin name \"min\" has been overriden by datar.\n",
-      "[2021-07-16 15:27:42][datar][WARNING] Builtin name \"max\" has been overriden by datar.\n",
-      "[2021-07-16 15:27:42][datar][WARNING] Builtin name \"sum\" has been overriden by datar.\n",
-      "[2021-07-16 15:27:42][datar][WARNING] Builtin name \"abs\" has been overriden by datar.\n",
-      "[2021-07-16 15:27:42][datar][WARNING] Builtin name \"round\" has been overriden by datar.\n",
-      "[2021-07-16 15:27:42][datar][WARNING] Builtin name \"all\" has been overriden by datar.\n",
-      "[2021-07-16 15:27:42][datar][WARNING] Builtin name \"any\" has been overriden by datar.\n",
-      "[2021-07-16 15:27:42][datar][WARNING] Builtin name \"re\" has been overriden by datar.\n",
-      "[2021-07-16 15:27:42][datar][WARNING] Builtin name \"filter\" has been overriden by datar.\n",
-      "[2021-07-16 15:27:42][datar][WARNING] Builtin name \"slice\" has been overriden by datar.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div style=\"text-align: right; text-style: italic\">Try this notebook on <a target=\"_blank\" href=\"https://mybinder.org/v2/gh/pwwang/datar/93d069f3ca36711fc811c61dcf60e9fc3d1460a5?filepath=docs%2Fnotebooks%2Ffilter-joins.ipynb\">binder</a>.</div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "### # semi_join  "
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "##### Returns all rows from x with a match in y.\n",
-       "\n",
-       "See Also:  \n",
-       "&emsp;&emsp;[`inner_join()`](datar.dplyr.join.inner_join)  \n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "### # anti_join  "
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/markdown": [
-       "##### Returns all rows from x without a match in y.\n",
-       "\n",
-       "See Also:  \n",
-       "&emsp;&emsp;[`inner_join()`](datar.dplyr.join.inner_join)  \n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
    "source": [
     "# https://dplyr.tidyverse.org/reference/filter-joins.html\n",
     "\n",
@@ -104,23 +11,230 @@
     "\n",
     "%run nb_helpers.py\n",
     "nb_header(semi_join, anti_join, book='filter-joins')"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "[2021-07-20 13:02:39][datar][WARNING] Builtin name \"min\" has been overriden by datar.\n",
+      "[2021-07-20 13:02:39][datar][WARNING] Builtin name \"max\" has been overriden by datar.\n",
+      "[2021-07-20 13:02:39][datar][WARNING] Builtin name \"sum\" has been overriden by datar.\n",
+      "[2021-07-20 13:02:39][datar][WARNING] Builtin name \"abs\" has been overriden by datar.\n",
+      "[2021-07-20 13:02:39][datar][WARNING] Builtin name \"round\" has been overriden by datar.\n",
+      "[2021-07-20 13:02:39][datar][WARNING] Builtin name \"all\" has been overriden by datar.\n",
+      "[2021-07-20 13:02:39][datar][WARNING] Builtin name \"any\" has been overriden by datar.\n",
+      "[2021-07-20 13:02:39][datar][WARNING] Builtin name \"re\" has been overriden by datar.\n",
+      "[2021-07-20 13:02:39][datar][WARNING] Builtin name \"filter\" has been overriden by datar.\n",
+      "[2021-07-20 13:02:39][datar][WARNING] Builtin name \"slice\" has been overriden by datar.\n"
+     ]
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ],
+      "text/html": [
+       "<div style=\"text-align: right; text-style: italic\">Try this notebook on <a target=\"_blank\" href=\"https://mybinder.org/v2/gh/pwwang/datar/93d069f3ca36711fc811c61dcf60e9fc3d1460a5?filepath=docs%2Fnotebooks%2Ffilter-joins.ipynb\">binder</a>.</div>"
+      ]
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ],
+      "text/markdown": [
+       "### # semi_join  "
+      ]
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ],
+      "text/markdown": [
+       "##### Returns all rows from x with a match in y.\n",
+       "\n",
+       "See Also:  \n",
+       "&emsp;&emsp;[`inner_join()`](datar.dplyr.join.inner_join)  \n"
+      ]
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ],
+      "text/markdown": [
+       "### # anti_join  "
+      ]
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ],
+      "text/markdown": [
+       "##### Returns all rows from x without a match in y.\n",
+       "\n",
+       "See Also:  \n",
+       "&emsp;&emsp;[`inner_join()`](datar.dplyr.join.inner_join)  \n"
+      ]
+     },
+     "metadata": {}
+    }
+   ],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-07-16T22:27:41.370298Z",
+     "iopub.status.busy": "2021-07-16T22:27:41.368998Z",
+     "iopub.status.idle": "2021-07-16T22:27:42.302245Z",
+     "shell.execute_reply": "2021-07-16T22:27:42.302701Z"
+    }
+   }
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "technical-flavor",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-07-16T22:27:42.371916Z",
-     "iopub.status.busy": "2021-07-16T22:27:42.370067Z",
-     "iopub.status.idle": "2021-07-16T22:27:42.398547Z",
-     "shell.execute_reply": "2021-07-16T22:27:42.399395Z"
-    }
-   },
+   "source": [
+    "band_members"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
+      "text/plain": [
+       "      name     band\n",
+       "  <object> <object>\n",
+       "0     Mick   Stones\n",
+       "1     John  Beatles\n",
+       "2     Paul  Beatles"
+      ],
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>name</th>\n",
+       "      <th>band</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th style=\"font-style: italic;\" ></th>\n",
+       "      <td style=\"font-style: italic;\" >&lt;object&gt;</td>\n",
+       "      <td style=\"font-style: italic;\" >&lt;object&gt;</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Mick</td>\n",
+       "      <td>Stones</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>John</td>\n",
+       "      <td>Beatles</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Paul</td>\n",
+       "      <td>Beatles</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 2
+    }
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "source": [
+    "band_instruments"
+   ],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "      name    plays\n",
+       "  <object> <object>\n",
+       "0     John   guitar\n",
+       "1     Paul     bass\n",
+       "2    Keith   guitar"
+      ],
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>name</th>\n",
+       "      <th>plays</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th style=\"font-style: italic;\" ></th>\n",
+       "      <td style=\"font-style: italic;\" >&lt;object&gt;</td>\n",
+       "      <td style=\"font-style: italic;\" >&lt;object&gt;</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>John</td>\n",
+       "      <td>guitar</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Paul</td>\n",
+       "      <td>bass</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Keith</td>\n",
+       "      <td>guitar</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 3
+    }
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "source": [
+    "band_members >> semi_join(band_instruments)"
+   ],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "      name     band\n",
+       "  <object> <object>\n",
+       "1     John  Beatles\n",
+       "2     Paul  Beatles"
+      ],
       "text/html": [
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
@@ -148,38 +262,36 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>"
-      ],
-      "text/plain": [
-       "      name     band\n",
-       "  <object> <object>\n",
-       "1     John  Beatles\n",
-       "2     Paul  Beatles"
       ]
      },
-     "execution_count": 1,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 4
     }
    ],
-   "source": [
-    "band_members >> semi_join(band_instruments)"
-   ]
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-07-16T22:27:42.371916Z",
+     "iopub.status.busy": "2021-07-16T22:27:42.370067Z",
+     "iopub.status.idle": "2021-07-16T22:27:42.398547Z",
+     "shell.execute_reply": "2021-07-16T22:27:42.399395Z"
+    }
+   }
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "federal-tolerance",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2021-07-16T22:27:42.426844Z",
-     "iopub.status.busy": "2021-07-16T22:27:42.426222Z",
-     "iopub.status.idle": "2021-07-16T22:27:42.437212Z",
-     "shell.execute_reply": "2021-07-16T22:27:42.436497Z"
-    }
-   },
+   "execution_count": 5,
+   "source": [
+    "band_members >> anti_join(band_instruments, by={'name': 'name'})"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
+      "text/plain": [
+       "      name     band\n",
+       "  <object> <object>\n",
+       "0     Mick   Stones"
+      ],
       "text/html": [
        "<table border=\"1\" class=\"dataframe\">\n",
        "  <thead>\n",
@@ -202,21 +314,20 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>"
-      ],
-      "text/plain": [
-       "      name     band\n",
-       "  <object> <object>\n",
-       "0     Mick   Stones"
       ]
      },
-     "execution_count": 1,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 5
     }
    ],
-   "source": [
-    "band_members >> anti_join(band_instruments)"
-   ]
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-07-16T22:27:42.426844Z",
+     "iopub.status.busy": "2021-07-16T22:27:42.426222Z",
+     "iopub.status.idle": "2021-07-16T22:27:42.437212Z",
+     "shell.execute_reply": "2021-07-16T22:27:42.436497Z"
+    }
+   }
   }
  ],
  "metadata": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "datar"
-version = "0.4.0"
+version = "0.4.1"
 description = "Port of dplyr and other related R packages in python, using pipda."
 authors = ["pwwang <pwwang@pwwang.com>"]
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if os.path.exists(readme_path):
 setup(
     long_description=readme,
     name='datar',
-    version='0.4.0',
+    version='0.4.1',
     description='Port of dplyr and other related R packages in python, using pipda.',
     python_requires='==3.*,>=3.7.1',
     project_urls={"homepage": "https://github.com/pwwang/datar",

--- a/tests/test_core_grouped.py
+++ b/tests/test_core_grouped.py
@@ -106,7 +106,7 @@ def test_multi_cats():
     # It's 4 with pandas 1.2
     # But 3 with pandas 1.3
     if (
-        datar_versions().pandas < "1.3.0"
+        datar_versions(False).pandas < "1.3.0"
     ):  # note when it comes to '1.11.x' vs '1.2.x'
         assert len(gf._group_data) == 4
     else:
@@ -114,7 +114,7 @@ def test_multi_cats():
 
     gf = DataFrameGroupBy(df, _group_vars=list("abcd"), _group_drop=True)
     if (
-        datar_versions().pandas < "1.3.0"
+        datar_versions(False).pandas < "1.3.0"
     ):  # note when it comes to '1.11.x' vs '1.2.x'
         assert len(gf._group_data) == 4
     else:

--- a/tests/test_dplyr_join.py
+++ b/tests/test_dplyr_join.py
@@ -51,7 +51,15 @@ def test_filtering_joins_preserve_row_and_column_order():
     assert out.columns.tolist() == ["a", "b"]
     assert out.a.tolist() == [3,2]
 
+    out = semi_join(df1, df2)
+    assert out.columns.tolist() == ["a", "b"]
+    assert out.a.tolist() == [3,2]
+
     out = anti_join(df1, df2, by="a")
+    assert out.columns.tolist() == ["a", "b"]
+    assert out.a.tolist() == [4,1]
+
+    out = anti_join(df1, df2, by={"a": "a"})
     assert out.columns.tolist() == ["a", "b"]
     assert out.a.tolist() == [4,1]
 


### PR DESCRIPTION
- Don't use piping syntax internally (`>>=`)
- Add `python`, `numpy`, `executing` and `datar` version to `datar.datar_versions()`
- Fix #40: anti_join/semi_join not working when by is column mapping