### PR TITLE
0.4.2

### DIFF
--- a/datar/__init__.py
+++ b/datar/__init__.py
@@ -7,7 +7,7 @@ from .core import _frame_format_patch
 from .core.defaults import f
 
 __all__ = ('f', 'get_versions')
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 def get_versions(
     prnt: bool = True

--- a/datar/__init__.py
+++ b/datar/__init__.py
@@ -6,10 +6,10 @@ from .core import operator as _
 from .core import _frame_format_patch
 from .core.defaults import f
 
-__all__ = ('f', 'datar_versions')
+__all__ = ('f', 'get_versions')
 __version__ = "0.4.1"
 
-def datar_versions(
+def get_versions(
     prnt: bool = True
 ) -> Mapping[str, str]: # pragma: no cover
     """Print or return related versions which help for bug reporting.

--- a/datar/base/__init__.py
+++ b/datar/base/__init__.py
@@ -27,6 +27,7 @@ from .arithmetic import (
     abs as abs_,
     prod,
     sign,
+    signif,
     trunc,
     exp,
     log,

--- a/datar/base/__init__.py
+++ b/datar/base/__init__.py
@@ -25,11 +25,19 @@ from .arithmetic import (
     round as round_,
     sum as sum_,
     abs as abs_,
+    prod,
+    sign,
+    trunc,
+    exp,
+    log,
+    log2,
+    log10,
+    log1p
 )
 from .bessel import bessel_i, bessel_j, bessel_k, bessel_y
 from .casting import as_double, as_float, as_int, as_integer, as_numeric
 from .complex import arg, as_complex, conj, im, is_complex, mod, re as re_
-from .constants import LETTERS, Inf, letters, month_abb, month_name, pi
+from .constants import LETTERS, letters, month_abb, month_name, pi
 from .cum import cummax, cummin, cumprod, cumsum
 from .date import as_date
 from .factor import (
@@ -52,7 +60,7 @@ from .logical import (
     is_logical,
     is_true,
 )
-from .na import NA, NaN, any_na, is_na
+from .na import NA, NaN, any_na, is_na, Inf, is_finite, is_infinite, is_nan
 from .null import NULL, as_null, is_null
 from .random import set_seed
 from .seq import (
@@ -66,6 +74,7 @@ from .seq import (
     seq_along,
     seq_len,
     unique,
+    match
 )
 from .special import (
     beta,
@@ -99,6 +108,12 @@ from .string import (
     sub,
     substr,
     substring,
+    startswith,
+    endswith,
+    strtoi,
+    chartr,
+    tolower,
+    toupper,
 )
 from .table import table
 from .testing import (
@@ -145,6 +160,7 @@ from .verbs import (
     setequal,
     t,
     union,
+    max_col,
 )
 from .which import which, which_max, which_min
 

--- a/datar/base/constants.py
+++ b/datar/base/constants.py
@@ -7,7 +7,6 @@ import numpy
 # pylint: disable=invalid-name
 
 pi = math.pi
-Inf = numpy.inf
 
 letters = numpy.array(list(ascii_letters[:26]))
 LETTERS = numpy.array(list(ascii_letters[26:]))

--- a/datar/base/factor.py
+++ b/datar/base/factor.py
@@ -45,13 +45,26 @@ def levels(x: Any) -> ArrayLikeType:
         x: The categorical data
 
     Returns:
-        levels of the categorical data
+        levels of the categorical
+        None if x is not an categorical/factor
     """
     if not is_categorical_(x):
         return None
 
     return categorized(x).categories
 
+@register_func(None, context=Context.EVAL)
+def nlevels(x: Any) -> int:
+    """Get the number of levels of a factor
+
+    Args:
+        x: The data to get number of levels of
+
+    Returns:
+        Number of levels if x is a categorical/factor; otherwise 0
+    """
+    lvls = levels(x)
+    return 0 if lvls is None else len(lvls)
 
 def factor(
     x: Iterable[Any] = None,

--- a/datar/base/funs.py
+++ b/datar/base/funs.py
@@ -4,7 +4,8 @@ If a function uses DataFrame/DataFrameGroupBy as first argument, it may be
 registered by `register_verb` and should be placed in `./verbs.py`
 """
 import itertools
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable, Union
+import numpy
 
 import pandas
 from pandas import Categorical, DataFrame
@@ -86,6 +87,25 @@ def expandgrid(*args: Iterable[Any], **kwargs: Iterable[Any]) -> DataFrame:
         list(itertools.product(*iters.values())), columns=iters.keys()
     )
 
+@register_func(None, context=Context.EVAL)
+def outer(x, y, fun: Union[str, Callable] = "*") -> DataFrame:
+    """Compute the outer product of two vectors.
+
+    Args:
+        x: The first vector
+        y: The second vector
+        fun: The function to handle how the result of the elements from
+            the first and second vectors should be computed.
+            The function has to be vectorized at the second argument, and
+            return the same shape as y.
+
+    Returns:
+        The data frame of the outer product of x and y
+    """
+    if fun == "*":
+        return DataFrame(numpy.outer(x, y))
+
+    return DataFrame([fun(xelem, y) for xelem in x])
 
 # ---------------------------------
 # Plain functions

--- a/datar/base/na.py
+++ b/datar/base/na.py
@@ -8,10 +8,12 @@ from pipda import register_func
 from ..core.contexts import Context
 from ..core.types import is_null, is_scalar
 from ..core.defaults import NA_REPR
+from ..core.utils import register_numpy_func_x
 
 # pylint: disable=invalid-name
 NA = numpy.nan
 NaN = NA
+Inf = numpy.inf
 
 # Just for internal and testing uses
 NA_character_ = NA_REPR
@@ -58,3 +60,45 @@ def any_na(x: Any, recursive: bool = False) -> bool:
         if any_na(elem, recursive=True):
             return True
     return out
+
+is_infinite = register_numpy_func_x(
+    "is_infinite",
+    "isinf",
+    doc="""Check if a value or values are infinite numbers
+
+    Args:
+        x: The value to check
+
+    Returns:
+        True if the value is infinite, False otherwise
+        For iterable values, returns the element-wise results
+    """
+)
+
+is_finite = register_numpy_func_x(
+    "is_finite",
+    "isfinite",
+    doc="""Check if a value or values are finite numbers
+
+    Args:
+        x: The value to check
+
+    Returns:
+        True if the value is finite, False otherwise
+        For iterable values, returns the element-wise results
+    """
+)
+
+is_nan = register_numpy_func_x(
+    "is_nan",
+    "isnan",
+    doc="""Check if a value or values are NaNs
+
+    Args:
+        x: The value to check
+
+    Returns:
+        True if the value is nan, False otherwise
+        For iterable values, returns the element-wise results
+    """
+)

--- a/datar/base/seq.py
+++ b/datar/base/seq.py
@@ -205,3 +205,33 @@ def c(*elems: Any) -> Collection:
         A collection of elements
     """
     return Collection(*elems)
+
+@register_func(None, context=Context.EVAL)
+def match(
+    x: Any,
+    table: Iterable,
+    nomatch: Any = -1,
+    # incomparables ...,
+    base0_: bool = None,
+) -> Iterable[int]:
+    """match returns a vector of the positions of (first) matches of
+    its first argument in its second.
+
+    See stackoverflow#4110059/pythonor-numpy-equivalent-of-match-in-r
+
+    Args:
+        x: The values to be matched
+        table: The values to be matched against
+        nomatch: The value to be returned in the case when no match is found
+            Instead of NA in R, this function takes -1 for non-matched elements
+            to keep the type as int.
+        base0_: Whether return indices are 0-based or not.
+            If not provided, will use `get_option('which_base_0')`
+    """
+    base = int(not get_option('which_base_0', base0_))
+    return Array([
+        table.index(elem) + base
+        if elem in table
+        else nomatch
+        for elem in x
+    ], dtype=int)

--- a/datar/base/testing.py
+++ b/datar/base/testing.py
@@ -22,6 +22,7 @@ from pipda import register_func
 from ..core.contexts import Context
 from ..core.types import TypeOrIter, BoolOrIter, is_scalar
 
+
 # pylint: disable=invalid-name
 
 
@@ -112,7 +113,7 @@ def is_atomic(x: Any) -> bool:
     return is_scalar(x)
 
 
-@register_func(None)
+@register_func(None, context=Context.EVAL)
 def is_element(elem: Any, elems: Iterable[Any]) -> BoolOrIter:
     """R's `is.element()` or `%in%`.
 
@@ -121,11 +122,10 @@ def is_element(elem: Any, elems: Iterable[Any]) -> BoolOrIter:
     We can't do `a %in% b` in python (`in` behaves differently), so
     use this function instead
     """
-    out = numpy.isin(elem, elems)
-    if is_scalar(elem):
+    out = numpy.in1d(elem, elems)
+    if is_scalar(elem): # necessary?
         return bool(out)
     return out
-
 
 is_in = is_element
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.4.2
+
+- Adopt `pipda` 0.4.4
+- Add `varname` to dependency to close #30
+- Rename `datar.datar_versions` to `datar.get_versions`
+- Port a set of functions from r-base, incluing:
+    - `prod`, `sign`, `signif`, `trunc`, `exp`, `log`, `log2`, `log10`, `log1p`,
+    - `is_finite`, `is_infinite`, `is_nan`,
+    - `match`,
+    - `startswith`, `endswith`, `strtoi`, `chartr`, `tolower`, `toupper`,
+    - `max_col`
+
+
 ## 0.4.1
 
 - Don't use piping syntax internally (`>>=`)

--- a/docs/reference-maps/base.md
+++ b/docs/reference-maps/base.md
@@ -25,7 +25,6 @@
 |API|Description|Notebook example|
 |---|---|---:|
 |`pi`|the ratio of the circumference of a circle to its diameter.|[:material-notebook:][4]|
-|`Inf`|Infinite number|[:material-notebook:][4]|
 |`letters`|the 26 lower-case letters of the Roman alphabet|[:material-notebook:][4]|
 |`LETTERS`|the 26 upper-case letters of the Roman alphabet|[:material-notebook:][4]|
 |`month.abb`|the three-letter abbreviations for the English month names|[:material-notebook:][4]|
@@ -56,182 +55,202 @@
 |[`floor()`][19]|Get the floor integers of the numbers|[:material-notebook:][4]|
 |[`sqrt()`][20]|Get the square root of the numbers|[:material-notebook:][4]|
 |[`cov()`][21]|Calculate the covariance of the values|[:material-notebook:][4]|
+|[`prod()`][117]|Calculate Product of the input||
+|[`sign()`][118]|Get the signs of the corresponding elements of x||
+|[`signif()`][125]|Rounds the values in its first argument to the specified number of significant digits||
+|[`trunc()`][119]|Get the integers truncated for each element in x||
+|[`exp()`][120]|Calculates the power of natural number||
+|[`log()`][121]|Computes logarithms, by default natural logarithm||
+|[`log2()`][122]|Computes logarithms with base 2||
+|[`log10()`][123]|Computes logarithms with base 10||
+|[`log1p()`][124]|Computes log(1+x)||
 
 ### Bessel functions
 
 |API|Description|Notebook example|
 |---|---|---:|
-|[`bessel_i`][22]|Bessel Functions of integer and fractional order of first kind|[:material-notebook:][4]
-|[`bessel_k`][24]|Bessel Functions of integer and fractional order of second kind|[:material-notebook:][4]
-|[`bessel_j`][23]|Modified Bessel functions of first kind|[:material-notebook:][4]
-|[`bessel_y`][25]|Modified Bessel functions of third kind|[:material-notebook:][4]
+|[`bessel_i`][22]|Bessel Functions of integer and fractional order of first kind|[:material-notebook:][4]|
+|[`bessel_k`][24]|Bessel Functions of integer and fractional order of second kind|[:material-notebook:][4]|
+|[`bessel_j`][23]|Modified Bessel functions of first kind|[:material-notebook:][4]|
+|[`bessel_y`][25]|Modified Bessel functions of third kind|[:material-notebook:][4]|
 
 ### Casting values between types
 
 |API|Description|Notebook example|
 |---|---|---:|
-|[`as_integer`][26] [`as_int`][]|Cast data to integer|[:material-notebook:][4]
-|[`as_double`][27]|Cast data to double (`numpy.float64`)|[:material-notebook:][4]
-|[`as_float`][28]|Cast data to float (`numpy.float_`)|[:material-notebook:][4]
-|[`as_numeric`][29]|Cast data to numeric|[:material-notebook:][4]
+|[`as_integer`][26] [`as_int`][]|Cast data to integer|[:material-notebook:][4]|
+|[`as_double`][27]|Cast data to double (`numpy.float64`)|[:material-notebook:][4]|
+|[`as_float`][28]|Cast data to float (`numpy.float_`)|[:material-notebook:][4]|
+|[`as_numeric`][29]|Cast data to numeric|[:material-notebook:][4]|
 
 ### Complex numbers
 
 |API|Description|Notebook example|
 |---|---|---:|
-|[`re`][30]|Get the real part of a complex number|[:material-notebook:][4]
-|[`mod`][31]|Get the modulus of a complex number|[:material-notebook:][4]
-|[`im`][32]|Get the imaginary part of a complex number|[:material-notebook:][4]
-|[`arg`][33]|Get the argument of a complex number|[:material-notebook:][4]
-|[`conj`][34]|Get the complex conjugate of a complex number|[:material-notebook:][4]
-|[`is_complex`][35]|Test if data is complex number|[:material-notebook:][4]
-|[`as_complex`][36]|Cast data to a complex number|[:material-notebook:][4]
+|[`re`][30]|Get the real part of a complex number|[:material-notebook:][4]|
+|[`mod`][31]|Get the modulus of a complex number|[:material-notebook:][4]|
+|[`im`][32]|Get the imaginary part of a complex number|[:material-notebook:][4]|
+|[`arg`][33]|Get the argument of a complex number|[:material-notebook:][4]|
+|[`conj`][34]|Get the complex conjugate of a complex number|[:material-notebook:][4]|
+|[`is_complex`][35]|Test if data is complex number|[:material-notebook:][4]|
+|[`as_complex`][36]|Cast data to a complex number|[:material-notebook:][4]|
 
 ### Cumulativate functions
 
 |API|Description|Notebook example|
 |---|---|---:|
-|[`cumsum`][37]|Cummulative sum|[:material-notebook:][4]
-|[`cumprod`][38]|Cummulative product|[:material-notebook:][4]
-|[`cummin`][39]|Cummulative min|[:material-notebook:][4]
-|[`cummax`][40]|Cummulative max|[:material-notebook:][4]
+|[`cumsum`][37]|Cummulative sum|[:material-notebook:][4]|
+|[`cumprod`][38]|Cummulative product|[:material-notebook:][4]|
+|[`cummin`][39]|Cummulative min|[:material-notebook:][4]|
+|[`cummax`][40]|Cummulative max|[:material-notebook:][4]|
 
 ### Date functions
 
 |API|Description|Notebook example|
 |---|---|---:|
-|[`as_date`][41]|Cast data to date|[:material-notebook:][4]
+|[`as_date`][41]|Cast data to date|[:material-notebook:][4]|
 
 ### Factor data
 
 |API|Description|Notebook example|
 |---|---|---:|
-|[`factor`][42]|Construct factor|[:material-notebook:][4]
-|[`droplevels`][43]|Drop unused levels|[:material-notebook:][4]
-|[`levels`][44]|Get levels of factors|[:material-notebook:][4]
-|[`is_factor`][45] [`is_categorical`][45]|Test if data is factor|[:material-notebook:][4]
-|[`as_factor`][46] [`as_categorical`][46]|Cast data to factor|[:material-notebook:][4]
+|[`factor`][42]|Construct factor|[:material-notebook:][4]|
+|[`droplevels`][43]|Drop unused levels|[:material-notebook:][4]|
+|[`levels`][44]|Get levels of factors|[:material-notebook:][4]|
+|[`is_factor`][45] [`is_categorical`][45]|Test if data is factor|[:material-notebook:][4]|
+|[`as_factor`][46] [`as_categorical`][46]|Cast data to factor|[:material-notebook:][4]|
 
 ### Logical/Boolean values
 
 |API|Description|Notebook example|
 |---|---|---:|
-|`TRUE`|Logical true|[:material-notebook:][4]
-|`FALSE`|Logical false|[:material-notebook:][4]
-|[`is_true`][47]|Test if data is scalar true (R's `isTRUE`)|[:material-notebook:][4]
-|[`is_false`][48]|Test if data is scalar false (R's `FALSE`)|[:material-notebook:][4]
-|[`is_logical`][49] [`is_bool`][49]|Test if data is logical/boolean|[:material-notebook:][4]
-|[`as_logical`][50] [`as_bool`][50]|Cast data to logical/boolean|[:material-notebook:][4]
+|`TRUE`|Logical true|[:material-notebook:][4]|
+|`FALSE`|Logical false|[:material-notebook:][4]|
+|[`is_true`][47]|Test if data is scalar true (R's `isTRUE`)|[:material-notebook:][4]|
+|[`is_false`][48]|Test if data is scalar false (R's `FALSE`)|[:material-notebook:][4]|
+|[`is_logical`][49] [`is_bool`][49]|Test if data is logical/boolean|[:material-notebook:][4]|
+|[`as_logical`][50] [`as_bool`][50]|Cast data to logical/boolean|[:material-notebook:][4]|
 
 ### NA (missing values)
 
 |API|Description|Notebook example|
 |---|---|---:|
-|`NA`|Missing value|[:material-notebook:][4]
-|`NaN`|Missing value, same as `NA`|[:material-notebook:][4]
-|[`is_na`][51]|Test if data is NA|[:material-notebook:][4]
-|[`any_na`][52]|Test if any element is NA|[:material-notebook:][4]
+|`Inf`|Infinite number|[:material-notebook:][4]|
+|`NA`|Missing value|[:material-notebook:][4]|
+|`NaN`|Missing value, same as `NA`|[:material-notebook:][4]|
+|[`is_na()`][51]|Test if data is NA|[:material-notebook:][4]|
+|[`any_na()`][52]|Test if any element is NA|[:material-notebook:][4]|
+|[`is_finite`][126]|Test if x is finite||
+|[`is_infinite`][127]|Test if x is infinite||
+|[`is_nan`][128]|Test if x is nan||
 
 ### NULL
 
 |API|Description|Notebook example|
 |---|---|---:|
-|`NULL`|NULL value|[:material-notebook:][4]
-|[`is_null`][53]|Test if data is null|[:material-notebook:][4]
-|[`as_null`][54]|Cast anything to NULL|[:material-notebook:][4]
+|`NULL`|NULL value|[:material-notebook:][4]|
+|[`is_null`][53]|Test if data is null|[:material-notebook:][4]|
+|[`as_null`][54]|Cast anything to NULL|[:material-notebook:][4]|
 
 ### Random
 
 |API|Description|Notebook example|
 |---|---|---:|
-|[`set_seed`][55]|Set the randomization seed|[:material-notebook:][4]
+|[`set_seed`][55]|Set the randomization seed|[:material-notebook:][4]|
 
 ### Functions to create and manipulate sequences
 
 |API|Description|Notebook example|
 |---|---|---:|
-|[`c`][56]|Collection of data|[:material-notebook:][4]
-|[`seq`][57]|Generate sequence|[:material-notebook:][4]
-|[`seq_len`][58]|Generate sequence with length|[:material-notebook:][4]
-|[`seq_along`][59]|Generate sequence along with another sequence|[:material-notebook:][4]
-|[`rev`][60]|Reverse a sequence|[:material-notebook:][4]
-|[`rep`][61]|Generate sequence with repeats|[:material-notebook:][4]
-|[`lengths`][62]|Get the length of elements in the sequence|[:material-notebook:][4]
-|[`unique`][63]|Get the unique elements|[:material-notebook:][4]
-|[`sample`][64]|Sample the elements from sequence|[:material-notebook:][4]
-|[`length`][65]|Get the length of data|[:material-notebook:][4]
+|[`c`][56]|Collection of data|[:material-notebook:][4]|
+|[`seq`][57]|Generate sequence|[:material-notebook:][4]|
+|[`seq_len`][58]|Generate sequence with length|[:material-notebook:][4]|
+|[`seq_along`][59]|Generate sequence along with another sequence|[:material-notebook:][4]|
+|[`rev`][60]|Reverse a sequence|[:material-notebook:][4]|
+|[`rep`][61]|Generate sequence with repeats|[:material-notebook:][4]|
+|[`lengths`][62]|Get the length of elements in the sequence|[:material-notebook:][4]|
+|[`unique`][63]|Get the unique elements|[:material-notebook:][4]|
+|[`sample`][64]|Sample the elements from sequence|[:material-notebook:][4]|
+|[`length`][65]|Get the length of data|[:material-notebook:][4]|
+|[`match`][129]|match returns a vector of the positions of (first) matches of its first argument in its second.||
 
 ### Special functions
 
 |API|Description|Notebook example|
 |---|---|---:|
-|[`beta`][66]|Beta function|[:material-notebook:][4]
-|[`lbeta`][67]|Natural logarithm of beta function|[:material-notebook:][4]
-|[`gamma`][68]|Gamma function|[:material-notebook:][4]
-|[`lgamma`][69]|Natural logarithm of gamma function|[:material-notebook:][4]
-|[`digamma`][70]|the first derivatives of the logarithm of the gamma function.|[:material-notebook:][4]
-|[`trigamma`][71]|the second derivatives of the logarithm of the gamma function.|[:material-notebook:][4]
-|[`psigamma`][72]|polygamma funnction|[:material-notebook:][4]
-|[`choose`][73]|binomial coefficients|[:material-notebook:][4]
-|[`lchoose`][74]|the logarithms of binomial coefficients.|[:material-notebook:][4]
-|[`factorial`][75]|factorial|[:material-notebook:][4]
-|[`lfactorial`][76]|Natural logarithm of factorial|[:material-notebook:][4]
+|[`beta`][66]|Beta function|[:material-notebook:][4]|
+|[`lbeta`][67]|Natural logarithm of beta function|[:material-notebook:][4]|
+|[`gamma`][68]|Gamma function|[:material-notebook:][4]|
+|[`lgamma`][69]|Natural logarithm of gamma function|[:material-notebook:][4]|
+|[`digamma`][70]|the first derivatives of the logarithm of the gamma function.|[:material-notebook:][4]|
+|[`trigamma`][71]|the second derivatives of the logarithm of the gamma function.|[:material-notebook:][4]|
+|[`psigamma`][72]|polygamma funnction|[:material-notebook:][4]|
+|[`choose`][73]|binomial coefficients|[:material-notebook:][4]|
+|[`lchoose`][74]|the logarithms of binomial coefficients.|[:material-notebook:][4]|
+|[`factorial`][75]|factorial|[:material-notebook:][4]|
+|[`lfactorial`][76]|Natural logarithm of factorial|[:material-notebook:][4]|
 
 ### String functions
 
 |API|Description|Notebook example|
 |---|---|---:|
-|[`is_character`][77] [`is_str`][77] [`is_string`][77]|Test if data is string|[:material-notebook:][4]
-|[`as_character`][78] [`as_str`][78] [`as_string`][78]|Cast data to string|[:material-notebook:][4]
-|[`grep`][79]|Test if pattern in string|[:material-notebook:][4]
-|[`grepl`][80]|Logical version of `grep`|[:material-notebook:][4]
-|[`sub`][81]|Replace substrings in strings|[:material-notebook:][4]
-|[`gsub`][82]|Replace all matched substring in strings|[:material-notebook:][4]
-|[`nchar`][83]|Get length of string|[:material-notebook:][4]
-|[`nzhcar`][84]|Test if string is not empty|[:material-notebook:][4]
-|[`paste`][85]|Concatenate strings|[:material-notebook:][4]
-|[`paste0`][86]|Concatenate strings with `sep=''`|[:material-notebook:][4]
-|[`sprintf`][87]|C-style string formatting|[:material-notebook:][4]
-|[`substr`][88]|Get substring|[:material-notebook:][4]
-|[`substring`][89]|Get substring with a start only|[:material-notebook:][4]
-|[`strsplit`][90]|Split strings with delimiter|[:material-notebook:][4]
+|[`is_character`][77] [`is_str`][77] [`is_string`][77]|Test if data is string|[:material-notebook:][4]|
+|[`as_character`][78] [`as_str`][78] [`as_string`][78]|Cast data to string|[:material-notebook:][4]|
+|[`grep`][79]|Test if pattern in string|[:material-notebook:][4]|
+|[`grepl`][80]|Logical version of `grep`|[:material-notebook:][4]|
+|[`sub`][81]|Replace substrings in strings|[:material-notebook:][4]|
+|[`gsub`][82]|Replace all matched substring in strings|[:material-notebook:][4]|
+|[`nchar`][83]|Get length of string|[:material-notebook:][4]|
+|[`nzhcar`][84]|Test if string is not empty|[:material-notebook:][4]|
+|[`paste`][85]|Concatenate strings|[:material-notebook:][4]|
+|[`paste0`][86]|Concatenate strings with `sep=''`|[:material-notebook:][4]|
+|[`sprintf`][87]|C-style string formatting|[:material-notebook:][4]|
+|[`substr`][88]|Get substring|[:material-notebook:][4]|
+|[`substring`][89]|Get substring with a start only|[:material-notebook:][4]|
+|[`strsplit`][90]|Split strings with delimiter|[:material-notebook:][4]|
+|[`startswith`][130]|Test if strings start with given prefix||
+|[`endswith`][131]|Test if strings end with given suffix||
+|[`strtoi`][132]|Convert strings to integers||
+|[`chartr`][133]|Replace characters in strings||
+|[`tolower`][134]|Transform strings to lower case||
+|[`toupper`][135]|Transform strings to upper case||
 
 ### Table
 
 |API|Description|Notebook example|
 |---|---|---:|
-|[`table`][91]|Cross Tabulation and Table Creation|[:material-notebook:][4]
+|[`table`][91]|Cross Tabulation and Table Creation|[:material-notebook:][4]|
 
 ### Testing value types
 
 |API|Description|Notebook example|
 |---|---|---:|
-|[`is_double`][92] [`is_float`][92]|Test if data is double or float (`numpy.float_`)|[:material-notebook:][4]
-|[`is_integer`][93] [`is_int`][93]|Test if data is integer|[:material-notebook:][4]
-|[`is_numeric`][94]|Test if data is numeric|[:material-notebook:][4]
-|[`is_atomic`][95]|Test is data is atomic|[:material-notebook:][4]
-|[`is_element`][96] [`is_in`][96]|Test if value is an element of an array (R's `%in`)|[:material-notebook:][4]
+|[`is_double`][92] [`is_float`][92]|Test if data is double or float (`numpy.float_`)|[:material-notebook:][4]|
+|[`is_integer`][93] [`is_int`][93]|Test if data is integer|[:material-notebook:][4]|
+|[`is_numeric`][94]|Test if data is numeric|[:material-notebook:][4]|
+|[`is_atomic`][95]|Test is data is atomic|[:material-notebook:][4]|
+|[`is_element`][96] [`is_in`][96]|Test if value is an element of an array (R's `%in`)|[:material-notebook:][4]|
 
 ### Trigonometric and hyper bolic functions
 
 |API|Description|Notebook example|
 |---|---|---:|
-|[`cos`][97]|cosine|[:material-notebook:][4]
-|[`sin`][98]|sine|[:material-notebook:][4]
-|[`tan`][99]|tangent|[:material-notebook:][4]
-|[`acos`][100]|Arc-cosine|[:material-notebook:][4]
-|[`asin`][101]|Arc-sine|[:material-notebook:][4]
-|[`atan`][102]|Arc-tangent|[:material-notebook:][4]
-|[`atan2`][103]|`atan(y/x)`|[:material-notebook:][4]
-|[`cospi`][104]|`cos(pi*x)`|[:material-notebook:][4]
-|[`sinpi`][105]|`sin(pi*x)`|[:material-notebook:][4]
-|[`tanpi`][106]|`tan(pi*x)`|[:material-notebook:][4]
-|[`cosh`][107]|Hyperbolic cosine|[:material-notebook:][4]
-|[`sinh`][108]|Hyperbolic sine|[:material-notebook:][4]
-|[`tanh`][109]|Hyperbolic tangent|[:material-notebook:][4]
-|[`acosh`][110]|Hyperbolic cosine|[:material-notebook:][4]
-|[`asinh`][111]|Hyperbolic sine|[:material-notebook:][4]
-|[`atanh`][112]|Hyperbolic tangent|[:material-notebook:][4]
+|[`cos`][97]|cosine|[:material-notebook:][4]|
+|[`sin`][98]|sine|[:material-notebook:][4]|
+|[`tan`][99]|tangent|[:material-notebook:][4]|
+|[`acos`][100]|Arc-cosine|[:material-notebook:][4]|
+|[`asin`][101]|Arc-sine|[:material-notebook:][4]|
+|[`atan`][102]|Arc-tangent|[:material-notebook:][4]|
+|[`atan2`][103]|`atan(y/x)`|[:material-notebook:][4]|
+|[`cospi`][104]|`cos(pi*x)`|[:material-notebook:][4]|
+|[`sinpi`][105]|`sin(pi*x)`|[:material-notebook:][4]|
+|[`tanpi`][106]|`tan(pi*x)`|[:material-notebook:][4]|
+|[`cosh`][107]|Hyperbolic cosine|[:material-notebook:][4]|
+|[`sinh`][108]|Hyperbolic sine|[:material-notebook:][4]|
+|[`tanh`][109]|Hyperbolic tangent|[:material-notebook:][4]|
+|[`acosh`][110]|Hyperbolic cosine|[:material-notebook:][4]|
+|[`asinh`][111]|Hyperbolic sine|[:material-notebook:][4]|
+|[`atanh`][112]|Hyperbolic tangent|[:material-notebook:][4]|
 
 ### Which
 
@@ -244,10 +263,11 @@
 
 |API|Description|Notebook example|
 |---|---|---:|
-|[`cut`][113]|Convert Numeric to Factor|[:material-notebook:][4]
-|[`identity`][114]|Identity Function|[:material-notebook:][4]
-|[`expandgrid`][115]|Create a Data Frame from All Combinations of Factor Variables|[:material-notebook:][4]
-|[**`data_context`**][116]|Mimic R's `with`|[:material-notebook:][4]
+|[`cut`][113]|Convert Numeric to Factor|[:material-notebook:][4]|
+|[`identity`][114]|Identity Function|[:material-notebook:][4]|
+|[`expandgrid`][115]|Create a Data Frame from All Combinations of Factor Variables|[:material-notebook:][4]|
+|[`max_col`][136]|Find the maximum position for each row of a matrix||
+|[**`data_context`**][116]|Mimic R's `with`|[:material-notebook:][4]|
 
 
 [1]: ../../api/datar.base.which/#datar.dplyr.which.which
@@ -366,3 +386,23 @@
 [114]: ../../api/datar.core.funs/#datar.core.funs.identity
 [115]: ../../api/datar.core.funs/#datar.core.funs.expandgrid
 [116]: ../../api/datar.core.funs/#datar.core.funs.data_context
+[117]: ../../api/datar.core.arithmetic/#datar.core.arithmetic.prod
+[118]: ../../api/datar.core.arithmetic/#datar.core.arithmetic.sign
+[119]: ../../api/datar.core.arithmetic/#datar.core.arithmetic.trunc
+[120]: ../../api/datar.core.arithmetic/#datar.core.arithmetic.exp
+[121]: ../../api/datar.core.arithmetic/#datar.core.arithmetic.log
+[122]: ../../api/datar.core.arithmetic/#datar.core.arithmetic.log2
+[123]: ../../api/datar.core.arithmetic/#datar.core.arithmetic.log10
+[124]: ../../api/datar.core.arithmetic/#datar.core.arithmetic.log1p
+[125]: ../../api/datar.core.arithmetic/#datar.core.arithmetic.signif
+[126]: ../../api/datar.core.na/#datar.core.na.is_finite
+[127]: ../../api/datar.core.na/#datar.core.na.is_infinite
+[128]: ../../api/datar.core.na/#datar.core.na.is_nan
+[129]: ../../api/datar.core.seq/#datar.core.seq.match
+[130]: ../../api/datar.core.string/#datar.core.string.startswith
+[131]: ../../api/datar.core.string/#datar.core.string.endswith
+[132]: ../../api/datar.core.string/#datar.core.string.strtoi
+[133]: ../../api/datar.core.string/#datar.core.string.chartr
+[134]: ../../api/datar.core.string/#datar.core.string.tolower
+[135]: ../../api/datar.core.string/#datar.core.string.toupper
+[136]: ../../api/datar.core.verbs/#datar.core.verbs.max_col

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ python = "^3.7.1" # align with pandas
 pipda = "*"
 diot = "*"
 executing = "*"
+varname = "*"
 pandas = "^1.2"
 scipy = { version = "^1.6", optional = true }
 wcwidth = { version = "^0.2", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "datar"
-version = "0.4.1"
+version = "0.4.2"
 description = "Port of dplyr and other related R packages in python, using pipda."
 authors = ["pwwang <pwwang@pwwang.com>"]
 readme = "README.md"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ pipda
 pytest
 pytest-cov
 scipy==1.*,>=1.6.0
+varname
 wcwidth==0.*,>=0.2.0

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if os.path.exists(readme_path):
 setup(
     long_description=readme,
     name='datar',
-    version='0.4.1',
+    version='0.4.2',
     description='Port of dplyr and other related R packages in python, using pipda.',
     python_requires='==3.*,>=3.7.1',
     project_urls={"homepage": "https://github.com/pwwang/datar",

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
     package_dir={"": "."},
     package_data={"datar.datasets": ["*.gz"]},
     install_requires=['diot', 'executing', 'pandas==1.*,>=1.2.0',
-                      'pipda', 'scipy==1.*,>=1.6.0', 'wcwidth==0.*,>=0.2.0'],
+                      'pipda', 'scipy==1.*,>=1.6.0', 'varname', 'wcwidth==0.*,>=0.2.0'],
     extras_require={"dev": ["pytest", "pytest-cov"]},
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,3 @@
-from pipda import register_verb, register_func
-register_verb.warn_astnode_failure = False
-register_func.warn_astnode_failure = False
+from pipda import options
+# don't warn on ast node detection failure in pytest assert statements
+options.warn_astnode_failure = False

--- a/tests/test_base_arithmetic.py
+++ b/tests/test_base_arithmetic.py
@@ -6,6 +6,7 @@ from datar.base import NA, colnames
 from datar.datar import drop_index
 from datar.tibble import tibble, tribble
 from datar.base.arithmetic import *
+from datar.base import pi
 from .conftest import assert_iterable_equal
 
 def test_sum():
@@ -140,3 +141,19 @@ def test_scale():
 
     df = tibble(x=[1,2,3], y=[4,5,6])
     assert_frame_equal(scale(df, False, False), df)
+
+def test_signif():
+    x2 = pi * 100. ** Array([-1,0,1,2,3])
+    out = signif(x2, 3)
+    assert_iterable_equal(
+        out,
+        [3.14e-02, 3.14e+00, 3.14e+02, 3.14e+04, 3.14e+06],
+        approx=True
+    )
+
+def test_log():
+    assert pytest.approx(log(exp(1))) == 1.0
+    assert pytest.approx(log(4, 4)) == 1.0
+    assert pytest.approx(log([exp(1), exp(2)])) == [1.0, 2.0]
+    assert pytest.approx(log2(2)) == 1.0
+    assert pytest.approx(log10(10)) == 1.0

--- a/tests/test_base_factor.py
+++ b/tests/test_base_factor.py
@@ -34,3 +34,7 @@ def test_is_factor():
     out = as_factor([])
     assert is_factor(out)
     assert not is_factor([])
+
+def test_nlevels():
+    assert nlevels(1) == 0
+    assert nlevels(factor([1,2,3])) == 3

--- a/tests/test_base_funs.py
+++ b/tests/test_base_funs.py
@@ -3,7 +3,7 @@ import pytest
 from pandas import Interval, DataFrame
 from pandas.testing import assert_frame_equal
 from datar.base.funs import *
-from datar.base import table, pi
+from datar.base import table, pi, paste0
 from datar.stats import rnorm
 from .conftest import assert_iterable_equal
 
@@ -68,3 +68,16 @@ def test_data_context():
         'a': [1,1,2,2],
         'b': [3,4,3,4],
     }))
+
+def test_outer():
+    out = outer([1,2], [1,2,3])
+    assert_frame_equal(out, DataFrame([
+        [1,2,3],
+        [2,4,6]
+    ]))
+
+    out = outer([1,2], [1,2,3], fun=paste0)
+    assert_frame_equal(out, DataFrame([
+        ["11", "12", "13"],
+        ["21", "22", "23"]
+    ]))

--- a/tests/test_base_seq.py
+++ b/tests/test_base_seq.py
@@ -87,3 +87,7 @@ def test_length():
     assert length([1,2]) == 2
     assert_iterable_equal(lengths(1), [1])
     assert_iterable_equal(lengths([[1], [2,3]]), [1,2])
+
+def test_match():
+    out = match([1,2,3], [2,3,4])
+    assert_iterable_equal(out, [-1,0,1])

--- a/tests/test_base_string.py
+++ b/tests/test_base_string.py
@@ -115,3 +115,39 @@ def test_strsplit():
     assert len(out) == 2
     assert out[0] == ['a', 'b', 'c']
     assert out[1] == ['a.', '.c']
+
+def test_starts_endswith():
+    assert startswith("abc", "a")
+    assert endswith("abc", "c")
+    assert_iterable_equal(startswith(["abc", "def"], "a"), [True, False])
+    assert_iterable_equal(endswith(["abc", "def"], "c"), [True, False])
+
+def test_strtoi():
+    assert strtoi("8") == 8
+    assert strtoi("0b111") == 7
+    assert strtoi("0xf") == 15
+    assert_iterable_equal(strtoi(["8", "0b111", "0xf"]), [8, 7, 15])
+
+def test_chartr():
+    assert chartr("a", "A", "abc") == "Abc"
+    with pytest.warns(UserWarning):
+        chartr(["a", "b"], ["A", "B"], "abc")
+    with pytest.raises(ValueError):
+        chartr(["a", "b"], "A", "abc")
+
+    assert_iterable_equal(
+        chartr("a", "A", ["abc", "ade"]),
+        ["Abc", "Ade"]
+    )
+
+def test_transform_case():
+    assert tolower("aBc") == "abc"
+    assert toupper("aBc") == "ABC"
+    assert_iterable_equal(tolower(["aBc", "DeF"]), ["abc", "def"])
+    assert_iterable_equal(toupper(["aBc", "DeF"]), ["ABC", "DEF"])
+
+def test_trimws():
+    assert trimws(" a ") == "a"
+    assert_iterable_equal(trimws([" a ", " b "], "both"), ["a", "b"])
+    assert_iterable_equal(trimws([" a ", " b "], "left"), ["a ", "b "])
+    assert_iterable_equal(trimws([" a ", " b "], "right"), [" a", " b"])

--- a/tests/test_base_verbs.py
+++ b/tests/test_base_verbs.py
@@ -94,3 +94,27 @@ def test_duplicated():
     )
     df = tibble(x=[1,1,2,2])
     assert_iterable_equal(duplicated(df), [False, True, False, True])
+
+def test_max_col():
+    df = tibble(
+        a = [1,7,4],
+        b = [8,5,3],
+        c = [6,2,9],
+        d = [8,7,9]
+    )
+    assert_iterable_equal(
+        max_col(df[["a", "b", "c"]], "random"),
+        [1,0,2]
+    )
+    out = max_col(df, "random")
+    assert out[0] in [1,3]
+    assert out[1] in [0,3]
+    assert out[2] in [2,3]
+    assert_iterable_equal(
+        max_col(df, "first"),
+        [1,0,2]
+    )
+    assert_iterable_equal(
+        max_col(df, "last"),
+        [3,3,3]
+    )

--- a/tests/test_core_grouped.py
+++ b/tests/test_core_grouped.py
@@ -4,7 +4,7 @@ from pandas import Categorical, Series
 from pandas.testing import assert_frame_equal
 from datar.core.grouped import *
 from datar.base import NA, mean, as_character
-from datar import f, datar_versions
+from datar import f, get_versions
 from pipda.function import FastEvalFunction
 
 
@@ -106,7 +106,7 @@ def test_multi_cats():
     # It's 4 with pandas 1.2
     # But 3 with pandas 1.3
     if (
-        datar_versions(False).pandas < "1.3.0"
+        get_versions(False).pandas < "1.3.0"
     ):  # note when it comes to '1.11.x' vs '1.2.x'
         assert len(gf._group_data) == 4
     else:
@@ -114,7 +114,7 @@ def test_multi_cats():
 
     gf = DataFrameGroupBy(df, _group_vars=list("abcd"), _group_drop=True)
     if (
-        datar_versions(False).pandas < "1.3.0"
+        get_versions(False).pandas < "1.3.0"
     ):  # note when it comes to '1.11.x' vs '1.2.x'
         assert len(gf._group_data) == 4
     else:


### PR DESCRIPTION

- Adopt `pipda` 0.4.4
- Add `varname` to dependency to close #30
- Rename `datar.datar_versions` to `datar.get_versions`
- Port a set of functions from r-base, incluing:
    - `prod`, `sign`, `signif`, `trunc`, `exp`, `log`, `log2`, `log10`, `log1p`,
    - `is_finite`, `is_infinite`, `is_nan`,
    - `match`,
    - `startswith`, `endswith`, `strtoi`, `chartr`, `tolower`, `toupper`,
    - `max_col`
