### PR TITLE
🔖 0.7.2

### DIFF
--- a/datar/__init__.py
+++ b/datar/__init__.py
@@ -14,7 +14,7 @@ __all__ = (
 options(enable_pdtypes=True)
 
 __all__ = ("f", "get_versions")
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 
 
 def get_versions(prnt: bool = True):

--- a/datar/base/string.py
+++ b/datar/base/string.py
@@ -447,16 +447,16 @@ def sprintf(fmt, *args):
 
     from ..tibble import tibble
     df = tibble(fmt, *args, _name_repair="minimal")
-    apply_func = lambda row: (
+    aggfunc = lambda row: (
         np.nan
         if pd.isnull(row.values[0])
         else row.values[0] % tuple(row.values[1:])
     )
     if isinstance(df, TibbleGrouped):
-        return Tibble(df, copy=False).apply(apply_func, axis=1).groupby(
+        return Tibble(df, copy=False).agg(aggfunc, axis=1).groupby(
             df._datar["grouped"].grouper
         )
-    return df.apply(apply_func, axis=1)
+    return df.agg(aggfunc, axis=1)
 
 
 # substr, substring ----------------------------------

--- a/datar/tidyr/pivot_long.py
+++ b/datar/tidyr/pivot_long.py
@@ -31,12 +31,12 @@ def pivot_longer(
     names_prefix: str = None,
     names_sep: str = None,
     names_pattern: str = None,
-    names_dtypess=None,
+    names_dtypes=None,
     names_transform: Union[Callable, Mapping[str, Callable]] = None,
     names_repair="check_unique",
     values_to: str = "value",
     values_drop_na: bool = False,
-    values_dtypess=None,
+    values_dtypes=None,
     values_transform: Union[Callable, Mapping[str, Callable]] = None,
 ):
     """ "lengthens" data, increasing the number of rows and
@@ -86,8 +86,8 @@ def pivot_longer(
             or a single string (specifying a regular expression to split on).
         names_pattern: takes the same specification as extract(),
             a regular expression containing matching groups (()).
-        names_dtypess: and
-        values_dtypess: A list of column name-prototype pairs.
+        names_dtypes: and
+        values_dtypes: A list of column name-prototype pairs.
             A prototype (or dtypes for short) is a zero-length vector
             (like integer() or numeric()) that defines the type, class, and
             attributes of a vector. Use these arguments if you want to confirm
@@ -231,11 +231,11 @@ def pivot_longer(
         ret.dropna(subset=values_to, inplace=True)
 
     names_data = ret.loc[:, names_to]  # SettingwithCopyWarning
-    apply_dtypes(names_data, names_dtypess)
+    apply_dtypes(names_data, names_dtypes)
     ret[names_to] = names_data
 
     values_data = ret[values_to]
-    apply_dtypes(values_data, values_dtypess)
+    apply_dtypes(values_data, values_dtypes)
     ret[values_to] = values_data
 
     if names_transform:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.7.2
+
+- ✨ Allow tidyr.unite() to unite multiple columns into a list, instead of join them (#105)
+- 🩹 Typos in argument names of tidyr.pivot_longer() (#104)
+- 🐛 Fix base.sprintf() not working with Series (#102)
+
 ## 0.7.1
 
 - 🐛 Fix settingwithcopywarning in tidyr.pivot_wider()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "datar"
-version = "0.7.1"
+version = "0.7.2"
 description = "Port of dplyr and other related R packages in python, using pipda."
 authors = ["pwwang <pwwang@pwwang.com>"]
 readme = "README.md"

--- a/tests/base/test_string.py
+++ b/tests/base/test_string.py
@@ -150,6 +150,9 @@ def test_sprintf():
     assert_iterable_equal(sprintf("%d", 1.1), ["1"])
     assert_iterable_equal(sprintf(["%d", "%.2f"], 1.1), ["1", "1.10"])
     assert_iterable_equal(sprintf(["%d", "%.2f"], 2.345), ["2", "2.35"])
+    assert_iterable_equal([sprintf(np.nan, 1.1)], [np.nan])
+    df = tibble(x=["%d", "%.2f"], y=[1.1, 2.345]).group_by("x")
+    assert_iterable_equal(sprintf(df.x, df.y).obj, ["1", "2.35"])
 
 
 def test_substr():

--- a/tests/tidyr/test_unite.py
+++ b/tests/tidyr/test_unite.py
@@ -61,3 +61,10 @@ def test_can_remove_missing_vars_on_request():
 #   expect_equal(vec_unite(df, c("x", "dbl")), c("x", "y", "z"))
 #   expect_equal(vec_unite(df, c("x", "chr")), c("x", "y", "z"))
 # })
+
+
+# GH#105
+def test_sep_none_does_not_join_strings():
+    df = tibble(x = "a", y = "b")
+    out = df >> unite('z', f[f.x:], sep = None)
+    assert_frame_equal(out, tibble(z = [["a", "b"]]))


### PR DESCRIPTION
- ✨ Allow `tidyr.unite()` to unite multiple columns into a list, instead of join them (#105)
- 🩹 Typos in argument names of `tidyr.pivot_longer()` (#104)
- 🐛 Fix `base.sprintf()` not working with `Series` (#102)